### PR TITLE
Fix gradle ndk to build release on App Center

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
     ext {
         buildToolsVersion = "30.0.2"
+        ndkVersion = "20.1.5948944"
         minSdkVersion = 16
         compileSdkVersion = 30
         targetSdkVersion = 30
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.3")
+        classpath("com.android.tools.build:gradle:4.1.0")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react": "16.13.1",
     "react-icons": "^3.11.0",
     "react-native": "0.63.2",
-    "react-native-config": "luggit/react-native-config#1eb6ac01991210ddad2989857359a0f6ee35d734",
+    "react-native-config": "^1.4.4",
     "react-native-datepicker": "^1.7.2",
     "react-native-gesture-handler": "^1.7.0",
     "react-native-iphone-x-helper": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6161,9 +6161,10 @@ react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-native-config@luggit/react-native-config#1eb6ac01991210ddad2989857359a0f6ee35d734:
-  version "0.11.7"
-  resolved "https://codeload.github.com/luggit/react-native-config/tar.gz/1eb6ac01991210ddad2989857359a0f6ee35d734"
+react-native-config@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/react-native-config/-/react-native-config-1.4.4.tgz#e0e10802d1e61ef051040c84dfd19f85a5984620"
+  integrity sha512-bu47sJHn/HrB7COAWBI8DieAhrbFLINHFE2HBCcVkDu0Y5ScrMs6vL+jhIm+pMSgxouseLhXG8h7xYYpxE38PA==
 
 react-native-datepicker@^1.7.2:
   version "1.7.2"


### PR DESCRIPTION
I'm using App Center to create and CI and we had a lot of problems with building a bundle one of them is NDK problem when I add NDK broked on react-native-config lib that we use I updated the lib and tried to build again.

I hope this PR fix it
```

> Task :app:copyReleaseBundledJs

> Task :app:stripReleaseDebugSymbols FAILED
Support for ANDROID_NDK_HOME is deprecated and will be removed in the future. Use android.ndkVersion in build.gradle instead.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:stripReleaseDebugSymbols'.
> No toolchains found in the NDK toolchains folder for ABI with prefix: arm-linux-androideabi

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 4m 0s
```